### PR TITLE
Prepare for CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 auxiliary
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^README\.Rmd$
+cran-comments.md

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,10 +13,11 @@ Authors@R: c(
            email = "amandachen@utexas.edu",
            role = c("aut")))
 Maintainer: James Pustejovsky <jepusto@gmail.com>
-Description: Provides analytic derivatives and information matrices for fitted lmeStruct models from nlme::lme(). 
-    The package includes functions for estimating the inverse of the expected or average Fisher information matrix of the 
-    full maximum or restricted maximum likelihood. It entails estimating the sampling variance of variance parameters, 
-    including the parameters of the random effects structure, variance structure and correlation structure.
+Description: Provides analytic derivatives and information matrices for fitted lmeStruct models from nlme::lme().
+    The package includes functions for estimating the sampling variance-covariance of variance component parameters using 
+    the inverse Fisher information for fitted LME models. The variance component paramters include the parameters of the 
+    random effects structure, the variance structure and the correlation structure. The package entails the calculation of 
+    the inverse of expected or average Fisher information matrix of the full maximum or restricted maximum likelihood.
 URL: https://github.com/jepusto/lmeInfo
 BugReports: https://github.com/jepusto/lmeInfo/issues
 License: GPL-3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: lmeInfo
+Type: Package
 Title: Information Matrices for lmeStruct Objects
-Version: 0.1.0.9000
+Version: 0.1.0
 Authors@R: c(
     person(given = "James", 
            family = "Pustejovsky", 
@@ -11,7 +12,11 @@ Authors@R: c(
            family = "Chen",
            email = "amandachen@utexas.edu",
            role = c("aut")))
-Description: Provides analytic derivatives and information matrices for fitted lmeStruct models from nlme::lme().
+Maintainer: James Pustejovsky <jepusto@gmail.com>
+Description: Provides analytic derivatives and information matrices for fitted lmeStruct models from nlme::lme(). 
+    The package includes functions for estimating the inverse of the expected or average Fisher information matrix of the 
+    full maximum or restricted maximum likelihood. It entails estimating the sampling variance of variance parameters, 
+    including the parameters of the random effects structure, variance structure and correlation structure.
 URL: https://github.com/jepusto/lmeInfo
 BugReports: https://github.com/jepusto/lmeInfo/issues
 License: GPL-3
@@ -36,3 +41,4 @@ Imports:
     stats
 VignetteBuilder: knitr
 RoxygenNote: 7.0.2
+Language: en-US

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,3 @@
+lmeInfo 0.1.0
+=======================
+* Initial release.

--- a/R/g_mlm.R
+++ b/R/g_mlm.R
@@ -43,25 +43,24 @@
 #' @examples
 #'
 #' library(nlme)
-#' data(Laski, package = "scdhlm")
-#' Laski_RML <- lme(fixed = outcome ~ treatment,
-#'                  random = ~ 1 | case,
-#'                  correlation = corAR1(0, ~ time | case),
-#'                  data = Laski)
-#' summary(Laski_RML)
-#' g_mlm(Laski_RML, p_const = c(0,1), r_const = c(1,0,1), returnModel = FALSE)
+#' data(Bryant2016, package = "lmeInfo")
+#' Bryant2016_RML1 <- lme(fixed = outcome ~ treatment,
+#'                        random = ~ 1 | school/case,
+#'                        correlation = corAR1(0, ~ session | school/case),
+#'                        data = Bryant2016)
+#' summary(Bryant2016_RML1)
+#' Bryant2016_g1 <- g_mlm(Bryant2016_RML1, p_const = c(0,1), r_const = c(1,1,0,1),
+#'                        infotype = "expected", returnModel = TRUE)
+#' summary(Bryant2016_g1)
+#' print(Bryant2016_g1)
 #'
-#' data(Schutte, package = "scdhlm")
-#' Schutte$trt.week <- with(Schutte, unlist(tapply((treatment=="treatment") * week,
-#'          list(treatment,case), function(x) x - min(x))) + (treatment=="treatment"))
-#' Schutte$week <- Schutte$week - 9
-#' Schutte_RML <- lme(fixed = fatigue ~ week + treatment + trt.week,
-#'                    random = ~ week | case,
-#'                    correlation = corAR1(0.2, ~ week | case),
-#'                    data = subset(Schutte, case != 4))
-#' summary(Schutte_RML)
-#' Schutte_g <- g_mlm(Schutte_RML, p_const = c(0,0,1,7), r_const = c(1,0,0,0,1))
-#' summary(Schutte_g)
+#' Bryant2016_RML4 <- lme(fixed = outcome ~ session_c + treatment + trt_time,
+#'                        random = list(~ 1 | school, ~ session_c | case),
+#'                        correlation = corAR1(0, ~ session_c | school/case),
+#'                        data = Bryant2016)
+#' Bryant2016_g4 <- g_mlm(Bryant2016_RML4, p_const = c(0,0,1,5), r_const = c(1,1,0,0,0,1))
+#' summary(Bryant2016_g4)
+#' print(Bryant2016_g4)
 
 g_mlm <- function(mod, p_const, r_const, infotype = "expected", returnModel = TRUE) {
 

--- a/R/information-matrices.R
+++ b/R/information-matrices.R
@@ -93,6 +93,7 @@ Q_matrix <- function(mod) {
 #'                  random = ~ 1 | case,
 #'                  correlation = corAR1(0, ~ time | case),
 #'                  data = Laski)
+#' Fisher_info(Laski_RML)
 #'
 #' @importFrom stats coef
 #' @importFrom stats dist
@@ -174,7 +175,7 @@ Fisher_info <- function(mod, type = "expected") {
 
     }
 
-  } else if (type == "averaged") {
+  } else if (type == "average") {
 
     rhat <- as.matrix(stats::residuals(mod, level = 0)) # fixed residuals
     Vinv_rhat <- prod_blockmatrix(A = V_inv, B = rhat)

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,88 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# lmeInfo
+
+<!-- badges: start -->
+[![Travis build status](https://travis-ci.org/jepusto/lmeInfo.svg?branch=master)](https://travis-ci.org/jepusto/lmeInfo)
+[![Codecov test coverage](https://codecov.io/gh/jepusto/lmeInfo/branch/master/graph/badge.svg)](https://codecov.io/gh/jepusto/lmeInfo?branch=master)
+<!-- badges: end -->
+
+## Information matrices for fitted nlme::lme models
+
+`lmeInfo` provides analytic derivatives and information matrices for fitted lmeStruct models from `nlme::lme()`. The package includes functions for estimating the inverse of the expected or average Fisher information matrix of the full maximum or restricted maximum likelihood. It entails estimating the sampling variance of variance parameters, including the parameters of the random effects structure, variance structure and correlation structure. Function is also available for calculating design-comparable standardized mean difference effect size (Pustejovsky et al., 2014) for multiple baseline across behaviors designs, multi-level multiple baseline designs, alternating treatment designs and meta-analyses.
+
+## Installation
+
+You can install the released version of lmeInfo from [CRAN](https://CRAN.R-project.org) with:
+
+```{r eval=FALSE}
+install.packages("lmeInfo")
+```
+
+You can also install the development version from [GitHub](https://github.com/) with:
+
+```{r, eval=FALSE}
+# install.packages("devtools")
+devtools::install_github("jepusto/lmeInfo")
+```
+
+## Demonstration
+
+We use the dataset from Bryant et al. (2016) to demonstrate how `lmeInfo` estimates the inverse Fisher information matrices for fitted LME models and calculates the design-comparable standardized mean difference effect size for a three-level multiple baseline design.
+
+- The inverse of Fisher information matrices
+
+```{r example}
+library(lmeInfo)
+library(nlme)
+data(Bryant2016)
+
+Bryant2016_RML <- lme(fixed = outcome ~ treatment,
+                      random = ~ 1 | school/case,
+                      correlation = corAR1(0, ~ session | school/case),
+                      data = Bryant2016)
+```
+
+The inverse of the expected Fisher information matrix of model `Bryant2016_RML` can be estimated using `Fisher_info()` in `lmeInfo` when the type argument is specified as __expected__. The inverse of the average Fisher information matrix is estimated when type is specified as __average__.
+
+```{r, eval = FALSE}
+Fisher_info(Bryant2016_RML, type = "expected")
+#>                             Tau.school.var((Intercept)) Tau.case.var((Intercept))    cor_params      sigma_sq
+#> Tau.school.var((Intercept))                1.322700e-05              3.481279e-06  4.031958e-02  2.034762e-06
+#> Tau.case.var((Intercept))                  3.481279e-06              1.299374e-05  1.510332e-01  7.536162e-06
+#> cor_params                                 4.031958e-02              1.510332e-01  2.744559e+05 -5.762687e+00
+#> sigma_sq                                   2.034762e-06              7.536162e-06 -5.762687e+00  1.320509e-04
+```
+
+- The design-comparable standardized mean difference effect size
+
+```{r}
+Bryant2016_g <- g_mlm(Bryant2016_RML, p_const = c(0,1), r_const = c(1,1,0,1))
+```
+
+```{r}
+print(Bryant2016_g)
+```
+
+Pustejovsky, Hedges & Shadish (2014) provides detailed estimation methods for the effect sizes, standard errors and degree of freedom.
+
+## References
+
+Bryant, B. R., Bryant, D. P., Porterfield, J., Dennis, M. S., Falcomata, T., Valentine, C., ... & Bell, K. (2016). The effects of a Tier 3 intervention on the mathematics performance of second grade students with severe mathematics difficulties. Journal of learning disabilities, 49(2), 176-188. doi:10.1177/0022219414538516
+
+Pustejovsky, J. E., Hedges, L. V., & Shadish, W. R. (2014). Design-comparable effect sizes
+in multiple baseline designs: A general modeling framework. Journal of Educational
+and Behavioral Statistics, 39 (5), 368–393. doi:10.3102/1076998614547577

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 ## Information matrices for fitted nlme::lme models
 
-`lmeInfo` provides analytic derivatives and information matrices for fitted lmeStruct models from `nlme::lme()`. The package includes functions for estimating the inverse of the expected or average Fisher information matrix of the full maximum or restricted maximum likelihood. It entails estimating the sampling variance of variance parameters, including the parameters of the random effects structure, variance structure and correlation structure. Function is also available for calculating design-comparable standardized mean difference effect size (Pustejovsky et al., 2014) for multiple baseline across behaviors designs, multi-level multiple baseline designs, alternating treatment designs and meta-analyses.
+`lmeInfo` provides analytic derivatives and information matrices for fitted lmeStruct models from `nlme::lme()`. The package includes functions for estimating the sampling variance-covariance of variance component parameters using the inverse Fisher information for fitted LME models. The variance component paramters include the parameters of the random effects structure, the variance structure and the correlation structure. The package entails the calculation of the inverse of the expected or average Fisher information matrix of the full maximum or restricted maximum likelihood. Function is also available for calculating design-comparable standardized mean difference effect size (Pustejovsky et al., 2014) for multiple baseline across behaviors designs, multi-level multiple baseline designs, alternating treatment designs and meta-analyses.
 
 ## Installation
 
@@ -41,9 +41,9 @@ devtools::install_github("jepusto/lmeInfo")
 
 ## Demonstration
 
-We use the dataset from Bryant et al. (2016) to demonstrate how `lmeInfo` estimates the inverse Fisher information matrices for fitted LME models and calculates the design-comparable standardized mean difference effect size for a three-level multiple baseline design.
+We use the dataset from Bryant et al. (2016) to demonstrate how `lmeInfo` estimates the sampling variance-covariance of variance component parameters of fitted LME models and calculates the design-comparable standardized mean difference effect size for a three-level multiple baseline design.
 
-- The inverse of Fisher information matrices
+### Sampling variance-covariance of variance component parameters
 
 ```{r example}
 library(lmeInfo)
@@ -56,28 +56,28 @@ Bryant2016_RML <- lme(fixed = outcome ~ treatment,
                       data = Bryant2016)
 ```
 
-The inverse of the expected Fisher information matrix of model `Bryant2016_RML` can be estimated using `Fisher_info()` in `lmeInfo` when the type argument is specified as __expected__. The inverse of the average Fisher information matrix is estimated when type is specified as __average__.
+The sampling variance-covariance of variance component parameters of model `Bryant2016_RML` can be estimated using `varcomp_vcov()` in `lmeInfo`. The sampling variance-covariance of variance component parameters is calculated using the inverse expected Fisher information when the type argument in `varcomp_vcov()` is specified as __expected__. The inverse of the average Fisher information matrix is estimated when the type argument is specified as __average__.
 
 ```{r, eval = FALSE}
-Fisher_info(Bryant2016_RML, type = "expected")
+varcomp_vcov(Bryant2016_RML, type = "expected")
 #>                             Tau.school.var((Intercept)) Tau.case.var((Intercept))    cor_params      sigma_sq
-#> Tau.school.var((Intercept))                1.322700e-05              3.481279e-06  4.031958e-02  2.034762e-06
-#> Tau.case.var((Intercept))                  3.481279e-06              1.299374e-05  1.510332e-01  7.536162e-06
-#> cor_params                                 4.031958e-02              1.510332e-01  2.744559e+05 -5.762687e+00
-#> sigma_sq                                   2.034762e-06              7.536162e-06 -5.762687e+00  1.320509e-04
+#> Tau.school.var((Intercept))                8.133900e+04             -2.140289e+04 -0.0100434219 -4.701744e+02
+#> Tau.case.var((Intercept))                 -2.140289e+04              3.996251e+05 -8.2280433012 -3.815479e+05
+#> cor_params                                -1.004342e-02             -8.228043e+00  0.0002154736  9.872975e+00
+#> sigma_sq                                  -4.701744e+02             -3.815479e+05  9.8729751627  4.602107e+05
 ```
 
-- The design-comparable standardized mean difference effect size
+### The design-comparable standardized mean difference effect size
+
+The design-comparable standardized mean difference effect size is calculated using `g_mlm()` in `lmeInfo`. The standard errors of the unadjusted or adjusted effect size are estimated with the inverse expected Fisher information matrix when the infotype argument in `g_mlm()` is specified as __expected__. The inverse average Fisher information matrix is used when the infotype argument is specified as __average__. The estimation method is built on the method described in Pustejovsky, Hedges, & Shadish (2014).
 
 ```{r}
-Bryant2016_g <- g_mlm(Bryant2016_RML, p_const = c(0,1), r_const = c(1,1,0,1))
+Bryant2016_g <- g_mlm(Bryant2016_RML, p_const = c(0,1), r_const = c(1,1,0,1), infotype = "expected")
 ```
 
 ```{r}
 print(Bryant2016_g)
 ```
-
-Pustejovsky, Hedges & Shadish (2014) provides detailed estimation methods for the effect sizes, standard errors and degree of freedom.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,112 @@
-<!-- badges: start -->
-[![Travis build status](https://travis-ci.org/jepusto/lmeInfo.svg?branch=master)](https://travis-ci.org/jepusto/lmeInfo)
-[![Codecov test coverage](https://codecov.io/gh/jepusto/lmeInfo/branch/master/graph/badge.svg)](https://codecov.io/gh/jepusto/lmeInfo?branch=master)
-<!-- badges: end -->
-  
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
 # lmeInfo
+
+<!-- badges: start -->
+
+[![Travis build
+status](https://travis-ci.org/jepusto/lmeInfo.svg?branch=master)](https://travis-ci.org/jepusto/lmeInfo)
+[![Codecov test
+coverage](https://codecov.io/gh/jepusto/lmeInfo/branch/master/graph/badge.svg)](https://codecov.io/gh/jepusto/lmeInfo?branch=master)
+<!-- badges: end -->
+
 ## Information matrices for fitted nlme::lme models
+
+`lmeInfo` provides analytic derivatives and information matrices for
+fitted lmeStruct models from `nlme::lme()`. The package includes
+functions for estimating the inverse of the expected or average Fisher
+information matrix of the full maximum or restricted maximum likelihood.
+It entails estimating the sampling variance of variance parameters,
+including the parameters of the random effects structure, variance
+structure and correlation structure. Function is also available for
+calculating design-comparable standardized mean difference effect size
+(Pustejovsky et al., 2014) for multiple baseline across behaviors
+designs, multi-level multiple baseline designs, alternating treatment
+designs and meta-analyses.
+
+## Installation
+
+You can install the released version of lmeInfo from
+[CRAN](https://CRAN.R-project.org) with:
+
+``` r
+install.packages("lmeInfo")
+```
+
+You can also install the development version from
+[GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("jepusto/lmeInfo")
+```
+
+## Demonstration
+
+We use the dataset from Bryant et al. (2016) to demonstrate how
+`lmeInfo` estimates the inverse Fisher information matrices for fitted
+LME models and calculates the design-comparable standardized mean
+difference effect size for a three-level multiple baseline design.
+
+  - The inverse of Fisher information matrices
+
+<!-- end list -->
+
+``` r
+library(lmeInfo)
+library(nlme)
+data(Bryant2016)
+
+Bryant2016_RML <- lme(fixed = outcome ~ treatment,
+                      random = ~ 1 | school/case,
+                      correlation = corAR1(0, ~ session | school/case),
+                      data = Bryant2016)
+```
+
+The inverse of the expected Fisher information matrix of model
+`Bryant2016_RML` can be estimated using `Fisher_info()` in `lmeInfo`
+when the type argument is specified as **expected**. The inverse of the
+average Fisher information matrix is estimated when type is specified as
+**average**.
+
+``` r
+Fisher_info(Bryant2016_RML, type = "expected")
+#>                             Tau.school.var((Intercept)) Tau.case.var((Intercept))    cor_params      sigma_sq
+#> Tau.school.var((Intercept))                1.322700e-05              3.481279e-06  4.031958e-02  2.034762e-06
+#> Tau.case.var((Intercept))                  3.481279e-06              1.299374e-05  1.510332e-01  7.536162e-06
+#> cor_params                                 4.031958e-02              1.510332e-01  2.744559e+05 -5.762687e+00
+#> sigma_sq                                   2.034762e-06              7.536162e-06 -5.762687e+00  1.320509e-04
+```
+
+  - The design-comparable standardized mean difference effect size
+
+<!-- end list -->
+
+``` r
+Bryant2016_g <- g_mlm(Bryant2016_RML, p_const = c(0,1), r_const = c(1,1,0,1))
+```
+
+``` r
+print(Bryant2016_g)
+#>                           est    se
+#> unadjusted effect size  0.481 0.122
+#> adjusted effect size    0.463 0.118
+#> degree of freedom      20.169
+```
+
+Pustejovsky, Hedges & Shadish (2014) provides detailed estimation
+methods for the effect sizes, standard errors and degree of freedom.
+
+## References
+
+Bryant, B. R., Bryant, D. P., Porterfield, J., Dennis, M. S., Falcomata,
+T., Valentine, C., … & Bell, K. (2016). The effects of a Tier 3
+intervention on the mathematics performance of second grade students
+with severe mathematics difficulties. Journal of learning disabilities,
+49(2), 176-188. <doi:10.1177/0022219414538516>
+
+Pustejovsky, J. E., Hedges, L. V., & Shadish, W. R. (2014).
+Design-comparable effect sizes in multiple baseline designs: A general
+modeling framework. Journal of Educational and Behavioral Statistics, 39
+(5), 368–393. <doi:10.3102/1076998614547577>

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ coverage](https://codecov.io/gh/jepusto/lmeInfo/branch/master/graph/badge.svg)](
 
 `lmeInfo` provides analytic derivatives and information matrices for
 fitted lmeStruct models from `nlme::lme()`. The package includes
-functions for estimating the inverse of the expected or average Fisher
-information matrix of the full maximum or restricted maximum likelihood.
-It entails estimating the sampling variance of variance parameters,
-including the parameters of the random effects structure, variance
-structure and correlation structure. Function is also available for
+functions for estimating the sampling variance-covariance of variance
+component parameters using the inverse Fisher information for fitted LME
+models. The variance component paramters include the parameters of the
+random effects structure, the variance structure and the correlation
+structure. The package entails the calculation of the inverse of the
+expected or average Fisher information matrix of the full maximum or
+restricted maximum likelihood. Function is also available for
 calculating design-comparable standardized mean difference effect size
 (Pustejovsky et al., 2014) for multiple baseline across behaviors
 designs, multi-level multiple baseline designs, alternating treatment
@@ -45,13 +47,12 @@ devtools::install_github("jepusto/lmeInfo")
 ## Demonstration
 
 We use the dataset from Bryant et al. (2016) to demonstrate how
-`lmeInfo` estimates the inverse Fisher information matrices for fitted
-LME models and calculates the design-comparable standardized mean
-difference effect size for a three-level multiple baseline design.
+`lmeInfo` estimates the sampling variance-covariance of variance
+component parameters of fitted LME models and calculates the
+design-comparable standardized mean difference effect size for a
+three-level multiple baseline design.
 
-  - The inverse of Fisher information matrices
-
-<!-- end list -->
+### Sampling variance-covariance of variance component parameters
 
 ``` r
 library(lmeInfo)
@@ -64,27 +65,36 @@ Bryant2016_RML <- lme(fixed = outcome ~ treatment,
                       data = Bryant2016)
 ```
 
-The inverse of the expected Fisher information matrix of model
-`Bryant2016_RML` can be estimated using `Fisher_info()` in `lmeInfo`
-when the type argument is specified as **expected**. The inverse of the
-average Fisher information matrix is estimated when type is specified as
-**average**.
+The sampling variance-covariance of variance component parameters of
+model `Bryant2016_RML` can be estimated using `varcomp_vcov()` in
+`lmeInfo`. The sampling variance-covariance of variance component
+parameters is calculated using the inverse expected Fisher information
+when the type argument in `varcomp_vcov()` is specified as **expected**.
+The inverse of the average Fisher information matrix is estimated when
+the type argument is specified as **average**.
 
 ``` r
-Fisher_info(Bryant2016_RML, type = "expected")
+varcomp_vcov(Bryant2016_RML, type = "expected")
 #>                             Tau.school.var((Intercept)) Tau.case.var((Intercept))    cor_params      sigma_sq
-#> Tau.school.var((Intercept))                1.322700e-05              3.481279e-06  4.031958e-02  2.034762e-06
-#> Tau.case.var((Intercept))                  3.481279e-06              1.299374e-05  1.510332e-01  7.536162e-06
-#> cor_params                                 4.031958e-02              1.510332e-01  2.744559e+05 -5.762687e+00
-#> sigma_sq                                   2.034762e-06              7.536162e-06 -5.762687e+00  1.320509e-04
+#> Tau.school.var((Intercept))                8.133900e+04             -2.140289e+04 -0.0100434219 -4.701744e+02
+#> Tau.case.var((Intercept))                 -2.140289e+04              3.996251e+05 -8.2280433012 -3.815479e+05
+#> cor_params                                -1.004342e-02             -8.228043e+00  0.0002154736  9.872975e+00
+#> sigma_sq                                  -4.701744e+02             -3.815479e+05  9.8729751627  4.602107e+05
 ```
 
-  - The design-comparable standardized mean difference effect size
+### The design-comparable standardized mean difference effect size
 
-<!-- end list -->
+The design-comparable standardized mean difference effect size is
+calculated using `g_mlm()` in `lmeInfo`. The standard errors of the
+unadjusted or adjusted effect size are estimated with the inverse
+expected Fisher information matrix when the infotype argument in
+`g_mlm()` is specified as **expected**. The inverse average Fisher
+information matrix is used when the infotype argument is specified as
+**average**. The estimation method is built on the method described in
+Pustejovsky, Hedges, & Shadish (2014).
 
 ``` r
-Bryant2016_g <- g_mlm(Bryant2016_RML, p_const = c(0,1), r_const = c(1,1,0,1))
+Bryant2016_g <- g_mlm(Bryant2016_RML, p_const = c(0,1), r_const = c(1,1,0,1), infotype = "expected")
 ```
 
 ``` r
@@ -94,9 +104,6 @@ print(Bryant2016_g)
 #> adjusted effect size    0.463 0.118
 #> degree of freedom      20.169
 ```
-
-Pustejovsky, Hedges & Shadish (2014) provides detailed estimation
-methods for the effect sizes, standard errors and degree of freedom.
 
 ## References
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,7 @@
+# Test environments
+* local Windows 10 Pro, R 3.6.2
+* Ubuntu 16.04.6 LTS (on travis-ci), R 3.6.2
+* win-builder (devel and release)
+
+# R CMD check results
+There were no ERRORs, WARNINGs or NOTEs. 

--- a/man/g_mlm.Rd
+++ b/man/g_mlm.Rd
@@ -44,25 +44,24 @@ from a multiple baseline design, using adjusted mlm method as described in Puste
 \examples{
 
 library(nlme)
-data(Laski, package = "scdhlm")
-Laski_RML <- lme(fixed = outcome ~ treatment,
-                 random = ~ 1 | case,
-                 correlation = corAR1(0, ~ time | case),
-                 data = Laski)
-summary(Laski_RML)
-g_mlm(Laski_RML, p_const = c(0,1), r_const = c(1,0,1), returnModel = FALSE)
+data(Bryant2016, package = "lmeInfo")
+Bryant2016_RML1 <- lme(fixed = outcome ~ treatment,
+                       random = ~ 1 | school/case,
+                       correlation = corAR1(0, ~ session | school/case),
+                       data = Bryant2016)
+summary(Bryant2016_RML1)
+Bryant2016_g1 <- g_mlm(Bryant2016_RML1, p_const = c(0,1), r_const = c(1,1,0,1),
+                       infotype = "expected", returnModel = TRUE)
+summary(Bryant2016_g1)
+print(Bryant2016_g1)
 
-data(Schutte, package = "scdhlm")
-Schutte$trt.week <- with(Schutte, unlist(tapply((treatment=="treatment") * week,
-         list(treatment,case), function(x) x - min(x))) + (treatment=="treatment"))
-Schutte$week <- Schutte$week - 9
-Schutte_RML <- lme(fixed = fatigue ~ week + treatment + trt.week,
-                   random = ~ week | case,
-                   correlation = corAR1(0.2, ~ week | case),
-                   data = subset(Schutte, case != 4))
-summary(Schutte_RML)
-Schutte_g <- g_mlm(Schutte_RML, p_const = c(0,0,1,7), r_const = c(1,0,0,0,1))
-summary(Schutte_g)
+Bryant2016_RML4 <- lme(fixed = outcome ~ session_c + treatment + trt_time,
+                       random = list(~ 1 | school, ~ session_c | case),
+                       correlation = corAR1(0, ~ session_c | school/case),
+                       data = Bryant2016)
+Bryant2016_g4 <- g_mlm(Bryant2016_RML4, p_const = c(0,0,1,5), r_const = c(1,1,0,0,0,1))
+summary(Bryant2016_g4)
+print(Bryant2016_g4)
 }
 \references{
 Pustejovsky, J. E., Hedges, L. V., & Shadish, W. R. (2014).


### PR DESCRIPTION
- About the datasets
I have not deleted the Thiemann 2001, 2004 and Bryant 2018 from lmeInfo because the unit tests use them. We cannot pull those datasets from scdhlm because the updated scdhlm has not been released.

- README.rmd, README.md
README needs more editing...
  